### PR TITLE
CLI mara_cron.schedule-job

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This package contains the following cli commands:
 | -------------- | --------------
 | `mara_cron.enable --job-id "my_job_id" [--module "module_name"]` | Enables a specific job regardless of the configuration.
 | `mara_cron.disable --job-id "my_job_id" [--module "module_name"]` | Disables a specific job.
+| `mara_cron.schedule-job --job-id "my_job_id"` | Schedules a job to run in less than 1 minute.
 | `mara_cron.list-crontab` | Lists the current cron tab settings
 | `mara_cron.list-crontab --with-changes` | Lists the current cron tab including the changes not yet written
 | `mara_cron.write-crontab` | Writes all not published changes to the crontab

--- a/mara_cron/cli.py
+++ b/mara_cron/cli.py
@@ -2,7 +2,7 @@ import sys
 import click
 from mara_cron import config
 
-from . import crontab
+from . import crontab, job
 
 
 @click.command()
@@ -46,6 +46,22 @@ def enable(job_id: str, module_name: str):
     job.enable(True)
 
     cron.write()
+    sys.exit(0)
+
+
+@click.command()
+@click.option('--job-id', required=True,
+              help='The id of of the cron job.')
+def schedule_job(job_id: str):
+    """ Schedules a job to run. """
+    cronjob = job.find_job(job_id)
+    if not cronjob:
+        print('Could not find job id "{job_id}"')
+        sys.exit(1)
+
+    crontab.append_single_execution_job(cronjob)
+
+    print(f'Job {job_id} is scheduled to run in less than 1 minute')
     sys.exit(0)
 
 

--- a/mara_cron/cli.py
+++ b/mara_cron/cli.py
@@ -17,7 +17,7 @@ def disable(job_id: str, module_name: str):
     job = crontab.get_job(cron, job_id=job_id, module_name=module_name)
 
     if not job:
-        print('Could not find cronjob')
+        print(f'Could not find cronjob "{job_id}"', file=sys.stderr)
         sys.exit(1)
 
     job.enable(False)
@@ -40,7 +40,7 @@ def enable(job_id: str, module_name: str):
     job = crontab.get_job(cron, job_id=job_id, module_name=module_name)
 
     if not job:
-        print('Could not find cronjob')
+        print(f'Could not find cronjob "{job_id}"', file=sys.stderr)
         sys.exit(1)
 
     job.enable(True)
@@ -56,7 +56,7 @@ def schedule_job(job_id: str):
     """ Schedules a job to run. """
     cronjob = job.find_job(job_id)
     if not cronjob:
-        print('Could not find job id "{job_id}"')
+        print(f'Could not find job with id "{job_id}"', file=sys.stderr)
         sys.exit(1)
 
     crontab.append_single_execution_job(cronjob)

--- a/mara_cron/ui/schedule_run.py
+++ b/mara_cron/ui/schedule_run.py
@@ -17,11 +17,11 @@ def do_schedule_run(job_id: str):
     print(f'schedule {job_id}')
 
     return response.Response(
-        title=f'Task scheduled',
+        title=f'Job scheduled',
         html=bootstrap.card(
             body=_.div[
                     _.p[
-                        """The task is scheduled to run in less then 1 minute."""
+                        """The job is scheduled to run in less then 1 minute."""
                     ],
                     bootstrap.button(url='javascript:history.back()',
                                      label='Go to last page', icon='play',


### PR DESCRIPTION
Adds a CLI command to schedule a job to run in less than 1 minute.

This is helpful e.g. when you want to run a pipeline manually and you close the SSH session afterwards. The job will then silently run in the backround as cronjob...